### PR TITLE
Add optional parameter to only show information about source

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ This would load the configuration from the file `config.json`:
 php imapcopy.php config.json
 ```
 
-There is one optional parameter `-test`, which will perform a test run with no
+With the optional parameter `-test`, a test run will be performed with no
 changes made to the destination:
 
 ```
@@ -80,12 +80,20 @@ php imapcopy.php config.json -test
 
 A test run still produces all the console output of a regular run.
 
+The second optional parameter `-info` leads to an output with information about the folders, i.e. the names and numbers of folders found at the source, and counts the messages inside the folders:
+
+```
+php imapcopy.php config.json -info
+```
+
+No changes will be made to the destination either.
+
 ### Important Tip
 
 Avoid *any* change made to the source IMAP account, until you have completely
 copied it to the destination, especially if you need to run *imapcopy* several
 times to get the job fully done, e.g. due to errors. This also includes new
-incoming messages being delivered to the source IMAP account. 
+incoming messages being delivered to the source IMAP account.
 
 The reason is, that *imapcopy* counts all folders and their messages in the
 source IMAP account, before it actually starts copying them. The folder and
@@ -443,4 +451,3 @@ using `mappedFolders`.
 
 This software is distributed under the terms of the
 [GNU General Public License v3](https://www.gnu.org/licenses/gpl-3.0.en.html).
-

--- a/src/cli/imapcopy.php
+++ b/src/cli/imapcopy.php
@@ -11,6 +11,8 @@ if (2 > $argc) {
 	printf("usage: php %s <confFile> [<option>]\n", basename($argv[0]));
 	printf(" -test   perform a test run with no changes made (this will force a read-only\n");
 	printf("         connection to the source and will not open the destination at all)\n");
+	printf(" -info   check connection to source and show information about folders, i.e.\n");
+	printf("         show name and number of folder and count messages\n");
 	die();
 }
 else {
@@ -33,7 +35,7 @@ else {
 	array_shift($args);
 	array_shift($args);
 
-	$validArgs = array('-test');
+	$validArgs = array('-test', '-info');
 	$invalidArgs = array_diff($args, $validArgs);
 	if (!empty($invalidArgs)) {
 		printf("ERROR: invalid option(s): %s\n", implode(', ', $invalidArgs));
@@ -71,7 +73,7 @@ printf("\n");
 printf("*** opening destination\n");
 $dst = new Imap($conf['dst']);
 printf('    connecting via \'%s\'...', $dst->getMailbox());
-if (!$testRun) {
+if (!$testRun && !in_array('-info', $args)) {
 	$_ = $dst->connect();
 	printf(" %s\n", test($_));
 	if (!$dst->isConnected()) {
@@ -128,6 +130,10 @@ foreach ($srcFolders as $srcFolder) {
 	$srcMessagesCount += $srcFolderMessagesCount;
 }
 printf(">>> %d total source message(s) found\n", $srcMessagesCount);
+
+if (in_array('-info', $args)) {
+	die();
+}
 
 printf("\n");
 


### PR DESCRIPTION
This is useful to check connection to the source, without running through all of the messages, and to get information about the folders (e.g. the number used in the config).
Especially when there are many messages inside the folders, these information would be "far away" after running a full test.