### PR TITLE
Add support for user-defined flags (IMAP keywords)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ over 30,000 e-mail with lots of huge attachments stored across over 450 folders.
   * Flagged
   * Deleted
   * Draft
+* Optionally preserve user-defined flags (also known as "IMAP keywords" or "tags")
 * Optionally auto-remove invalid spaces from folder names
 * Support different folder separators for source and destination, e.g. `.` and
 `/`
@@ -194,6 +195,11 @@ the `readOnly` setting of the destination is overwritten with `true`.
 Set the folder separator used by the mail server. Typically it is a dot `.`
 (e.g. [Courier IMAP](http://www.courier-mta.org/imap/)) or a slash `/` (e.g.
 [Gmail](https://mail.google.com/)).
+
+#### flags
+
+To preserve user-defined flags (also known as "IMAP keywords" or "tags") in
+messages, set `flags` to `true` for the source and destination.
 
 ### Source-specific Settings
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ over 30,000 e-mail with lots of huge attachments stored across over 450 folders.
   * Flagged
   * Deleted
   * Draft
-* Optionally preserve user-defined flags (also known as "IMAP keywords" or "tags")
+* Optionally preserve [user-defined flags](https://tools.ietf.org/html/rfc5788#section-1) (also known as "IMAP keywords" or "tags")
 * Optionally auto-remove invalid spaces from folder names
 * Support different folder separators for source and destination, e.g. `.` and
 `/`

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ The configuration is provided as a file written using the
 		"sslNovalidateCert": false,
 		"readOnly": true,
 		"folderSeparator": ".",
+		"flags": true,
 
 		"excludedFolders": [
 			"INBOX.Drafts",
@@ -148,6 +149,7 @@ The configuration is provided as a file written using the
 		"sslNovalidateCert": false,
 		"readOnly": false,
 		"folderSeparator": "/",
+		"flags": true,
 
 		"trimFolderPath": true,
 		"mappedFolders": {

--- a/conf/example.json
+++ b/conf/example.json
@@ -8,6 +8,7 @@
 		"sslNovalidateCert": false,
 		"readOnly": true,
 		"folderSeparator": ".",
+		"flags": true,
 
 		"excludedFolders": [
 			"INBOX.Drafts",
@@ -31,6 +32,7 @@
 		"sslNovalidateCert": false,
 		"readOnly": false,
 		"folderSeparator": "/",
+		"flags": true,
 
 		"trimFolderPath": true,
 		"mappedFolders": {

--- a/src/cli/imapcopy.php
+++ b/src/cli/imapcopy.php
@@ -108,6 +108,7 @@ printf("\n");
 
 printf('*** counting total source messages...');
 $srcFolderMessagesCounts = array();
+$srcFolderMessagesFlags = array();
 $srcMessagesCount = 0;
 $srcFolderNum = 0;
 foreach ($srcFolders as $srcFolder) {
@@ -129,6 +130,10 @@ foreach ($srcFolders as $srcFolder) {
 
 	$srcFolderMessagesCounts[$srcFolderNum] = $srcFolderMessagesCount;
 	$srcMessagesCount += $srcFolderMessagesCount;
+
+	if ($src->isMessageFlagsEnabled()) {
+		$srcFolderMessagesFlags[$srcFolderNum] = $src->getFolderMessagesFlags($srcFolderMessagesCount);
+	}
 }
 printf(">>> %d total source message(s) found\n", $srcMessagesCount);
 
@@ -228,7 +233,13 @@ foreach ($srcFolders as $srcFolder) {
 
 		printf('            storing destination message...');
 		if (!$testRun) {
-			$_ = $dst->storeMessage($dstFolder, $srcMessage, $srcMessageHeaderInfo);
+			if ($src->isMessageFlagsEnabled() && $dst->isMessageFlagsEnabled()) {
+				$messageFlags = $srcFolderMessagesFlags[$srcFolderNum][$srcFolderMessageNum];
+			}
+			else {
+				$messageFlags = NULL;
+			}
+			$_ = $dst->storeMessage($dstFolder, $srcMessage, $srcMessageHeaderInfo, $messageFlags);
 			printf(" %s\n", test($_));
 		}
 		else {

--- a/src/lib/classes/Imap.php
+++ b/src/lib/classes/Imap.php
@@ -307,8 +307,9 @@ class Imap {
 		if (isset($conf['flags']) && !empty($conf['flags'])) {
 			return true;
 		}
-		else
+		else {
 			return false;
+		}
 	}
 
 	public function getFolderMessagesFlags($length) {
@@ -320,14 +321,14 @@ class Imap {
 			foreach ($headers as $header) {
 				$flags = NULL;
 
-				if (preg_match("/{.*?}/", $header, $matches, PREG_OFFSET_CAPTURE, $FLAGS_OFFSET) == true) {
+				if (preg_match('/{.*?}/', $header, $matches, PREG_OFFSET_CAPTURE, $FLAGS_OFFSET) == true) {
 					foreach ($matches as $match) {
 						if ($match[1] != $FLAGS_OFFSET) {
 							continue;
 						}
 
-						$flags = ltrim($match[0], "{");
-						$flags = rtrim($flags, "}");
+						$flags = ltrim($match[0], '{');
+						$flags = rtrim($flags, '}');
 						break;
 					}
 				}
@@ -337,7 +338,7 @@ class Imap {
 		}
 
 		// Need array to start at 1 to match message indices
-		array_unshift($messagesFlags, "dummy");
+		array_unshift($messagesFlags, NULL);
 		unset($messagesFlags[0]);
 
 		return $messagesFlags;

--- a/src/lib/classes/Imap.php
+++ b/src/lib/classes/Imap.php
@@ -246,9 +246,15 @@ class Imap {
 		return date('d-M-Y H:i:s O', $messageHeaderInfo->udate);
 	}
 
-	public function storeMessage($folder, $message, $headerInfo) {
+	public function storeMessage($folder, $message, $headerInfo, $messageFlags = NULL) {
+		$messageOptions = $this->getMessageOptions($headerInfo);
+
+		if ($this->isMessageFlagsEnabled() && $messageFlags != NULL) {
+			$messageOptions .= ' ' . $messageFlags;
+		}
+
 		return imap_append($this->getConnection(), $this->getFullFolderName($folder), $message,
-			$this->getMessageOptions($headerInfo),
+			$messageOptions,
 			$this->getMessageInternalDate($headerInfo));
 	}
 
@@ -294,4 +300,47 @@ class Imap {
 		}
 		return in_array($folderMessageNum, $onlyFolderMessagesNum);
 	}
+
+	public function isMessageFlagsEnabled() {
+		$conf = $this->getConf();
+
+		if (isset($conf['flags']) && !empty($conf['flags'])) {
+			return true;
+		}
+		else
+			return false;
+	}
+
+	public function getFolderMessagesFlags($length) {
+		$messagesFlags = array();
+		$FLAGS_OFFSET = 44;
+
+		$headers = imap_headers($this->getConnection());
+		if ($headers == true) {
+			foreach ($headers as $header) {
+				$flags = NULL;
+
+				if (preg_match("/{.*?}/", $header, $matches, PREG_OFFSET_CAPTURE, $FLAGS_OFFSET) == true) {
+					foreach ($matches as $match) {
+						if ($match[1] != $FLAGS_OFFSET) {
+							continue;
+						}
+
+						$flags = ltrim($match[0], "{");
+						$flags = rtrim($flags, "}");
+						break;
+					}
+				}
+
+				$messagesFlags[] = $flags;
+			}
+		}
+
+		// Need array to start at 1 to match message indices
+		array_unshift($messagesFlags, "dummy");
+		unset($messagesFlags[0]);
+
+		return $messagesFlags;
+	}
+
 }


### PR DESCRIPTION
Great script! However, I discovered that it doesn't preserve user-defined flags, also known as IMAP keywords. (See [here](https://tools.ietf.org/html/rfc5788#section-1) for a quick definition.) 

Some clients, such as Thunderbird, use these keywords extensively, both for arbitrary user-defined tags and for core functionality (for example, forwarded messages contain the "$Forwarded" flag, which Thunderbird uses to display a special icon next to the message).

This pull request adds support for IMAP keywords. I tested it on a migration of several mailboxes containing thousands of messages from a server running Courier to a server running Dovecot, and everything worked fine -- all of the keywords were transferred over.